### PR TITLE
auto network selection issue fix

### DIFF
--- a/src/components/SelectNetwork.jsx
+++ b/src/components/SelectNetwork.jsx
@@ -10,10 +10,18 @@ export const SelectNetwork = () => {
   };
 
   useEffect(() => {
-    if (window?.ethereum) {
-      const selectedNetwork = window.ethereum.networkVersion;
-      if (Network_IDs.includes(selectedNetwork)) setNetwork(selectedNetwork);
+    async function getSelectedNetwork() {
+      try {
+        const selectedNetwork = await window.ethereum.request({
+          method: "net_version",
+        });
+        if (Network_IDs.includes(selectedNetwork)) setNetwork(selectedNetwork);
+      } catch (e) {
+        console.error({ e });
+      }
     }
+
+    getSelectedNetwork();
   }, []);
 
   return (

--- a/src/context/network.jsx
+++ b/src/context/network.jsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState } from "react";
 
-const initialValue = "3";
+const initialValue = "42";
 
 const NetworkContext = createContext({
   network: initialValue,


### PR DESCRIPTION
- Kovan is made initial network
- newer API used for auto network selection `ethereum.request({ method: 'net_version' })`